### PR TITLE
Add Custom API Service

### DIFF
--- a/src/pyport/api_client.py
+++ b/src/pyport/api_client.py
@@ -11,6 +11,7 @@ from pyport.actions.actions_api_svc import Actions
 from pyport.apps.apps_api_svc import Apps
 from pyport.audit.audit_api_svc import Audit
 from pyport.checklist.checklist_api_svc import Checklist
+from pyport.custom.custom_api_svc import Custom
 from pyport.entities.entities_api_svc import Entities
 from pyport.integrations.integrations_api_svc import Integrations
 from pyport.migrations.migrations_api_svc import Migrations
@@ -83,6 +84,7 @@ class PortClient:
         self.checklist = Checklist(self)
         self.apps = Apps(self)
         self.scorecards = Scorecards(self)
+        self.custom = Custom(self)
 
     def _start_token_refresh_thread(self):
         refresh_thread = threading.Thread(target=self._token_refresh_loop, daemon=True)

--- a/src/pyport/custom/__init__.py
+++ b/src/pyport/custom/__init__.py
@@ -1,0 +1,1 @@
+"""Custom API service for sending custom requests to the Port API.""" 

--- a/src/pyport/custom/custom_api_svc.py
+++ b/src/pyport/custom/custom_api_svc.py
@@ -1,0 +1,50 @@
+from typing import Dict, Optional, Any, Union
+
+from pyport.models.api_category import BaseResource
+
+
+class Custom(BaseResource):
+    """Custom API category for sending custom requests to the Port API."""
+
+    def send_request(
+        self,
+        relative_path: str,
+        method: str = "GET",
+        headers: Optional[Dict[str, str]] = None,
+        params: Optional[Dict[str, Any]] = None,
+        data: Optional[Union[Dict[str, Any], str]] = None,
+        json_data: Optional[Dict[str, Any]] = None
+    ) -> Dict:
+        """
+        Send a custom request to the Port API.
+
+        :param relative_path: The relative URL/path to the API endpoint.
+        :param method: HTTP method (e.g., 'GET', 'POST', 'PUT', 'DELETE').
+        :param headers: Optional dictionary of HTTP headers to send.
+        :param params: Optional dictionary of query string parameters.
+        :param data: Optional data to send in the request body (form data or string).
+        :param json_data: Optional JSON data to send in the request body.
+        :return: The JSON response from the API.
+        """
+        # Ensure method is uppercase
+        method = method.upper()
+        
+        # Prepare kwargs for the request
+        kwargs = {}
+        if headers:
+            kwargs['headers'] = headers
+        if params:
+            kwargs['params'] = params
+        if data:
+            kwargs['data'] = data
+        if json_data:
+            kwargs['json'] = json_data
+            
+        # Make the request
+        response = self._client.make_request(method, relative_path, **kwargs)
+        
+        # Return the JSON response if the response has content
+        if response.content:
+            return response.json()
+        # Return an empty dict for responses with no content (e.g., 204 No Content)
+        return {}

--- a/tests/test_custom_api_svc.py
+++ b/tests/test_custom_api_svc.py
@@ -1,0 +1,93 @@
+import unittest
+from unittest.mock import MagicMock, patch
+from src.pyport.custom.custom_api_svc import Custom
+from src.pyport.api_client import PortClient
+
+
+class TestCustomService(unittest.TestCase):
+    def setUp(self):
+        patcher_env = patch('src.pyport.api_client.PortClient._get_local_env_cred', return_value=('dummy_id', 'dummy_secret'))
+        self.addCleanup(patcher_env.stop)
+        self.mock_get_local_env_cred = patcher_env.start()
+
+        patcher_token = patch('src.pyport.api_client.PortClient._get_access_token', return_value='dummy_token')
+        self.addCleanup(patcher_token.stop)
+        self.mock_get_access_token = patcher_token.start()
+
+        self.client = PortClient(client_secret="dummy_secret", client_id="dummy_id", us_region=True)
+        self.client.make_request = MagicMock()
+        self.custom = Custom(self.client)
+        self.test_path = "custom/endpoint"
+
+    def test_send_request_get(self):
+        # Test a simple GET request
+        dummy_response = MagicMock()
+        dummy_response.content = True
+        dummy_response.json.return_value = {"data": "test_data"}
+        self.client.make_request.return_value = dummy_response
+
+        result = self.custom.send_request(self.test_path)
+        self.client.make_request.assert_called_once_with('GET', self.test_path)
+        self.assertEqual(result, {"data": "test_data"})
+
+    def test_send_request_post_with_json(self):
+        # Test a POST request with JSON data
+        json_data = {"key": "value"}
+        dummy_response = MagicMock()
+        dummy_response.content = True
+        dummy_response.json.return_value = {"success": True}
+        self.client.make_request.return_value = dummy_response
+
+        result = self.custom.send_request(self.test_path, method="post", json_data=json_data)
+        self.client.make_request.assert_called_once_with('POST', self.test_path, json=json_data)
+        self.assertEqual(result, {"success": True})
+
+    def test_send_request_with_params(self):
+        # Test a request with query parameters
+        params = {"filter": "value"}
+        dummy_response = MagicMock()
+        dummy_response.content = True
+        dummy_response.json.return_value = {"filtered": "data"}
+        self.client.make_request.return_value = dummy_response
+
+        result = self.custom.send_request(self.test_path, params=params)
+        self.client.make_request.assert_called_once_with('GET', self.test_path, params=params)
+        self.assertEqual(result, {"filtered": "data"})
+
+    def test_send_request_with_headers(self):
+        # Test a request with custom headers
+        headers = {"X-Custom-Header": "value"}
+        dummy_response = MagicMock()
+        dummy_response.content = True
+        dummy_response.json.return_value = {"data": "with_custom_header"}
+        self.client.make_request.return_value = dummy_response
+
+        result = self.custom.send_request(self.test_path, headers=headers)
+        self.client.make_request.assert_called_once_with('GET', self.test_path, headers=headers)
+        self.assertEqual(result, {"data": "with_custom_header"})
+
+    def test_send_request_with_data(self):
+        # Test a request with form data
+        data = "raw_data"
+        dummy_response = MagicMock()
+        dummy_response.content = True
+        dummy_response.json.return_value = {"received": "raw_data"}
+        self.client.make_request.return_value = dummy_response
+
+        result = self.custom.send_request(self.test_path, method="PUT", data=data)
+        self.client.make_request.assert_called_once_with('PUT', self.test_path, data=data)
+        self.assertEqual(result, {"received": "raw_data"})
+
+    def test_send_request_no_content(self):
+        # Test a request that returns no content (e.g., 204 No Content)
+        dummy_response = MagicMock()
+        dummy_response.content = False
+        self.client.make_request.return_value = dummy_response
+
+        result = self.custom.send_request(self.test_path, method="DELETE")
+        self.client.make_request.assert_called_once_with('DELETE', self.test_path)
+        self.assertEqual(result, {})
+
+
+if __name__ == '__main__':
+    unittest.main() 


### PR DESCRIPTION
This PR introduces the complete Custom API service in the `src/pyport/custom/custom_api_svc.py` file, along with comprehensive unit tests in the `tests/test_custom_api_svc.py` file. 
The Custom API service allows for sending custom requests to the Port API, supporting various HTTP methods and request configurations.

The unit tests cover the following scenarios for the send_request method:
* Sending GET requests
* Sending POST requests with JSON data
* Sending requests with query parameters
* Sending requests with custom headers
* Sending requests with form data
* Handling requests that return no content
